### PR TITLE
Initialize global variables properly.

### DIFF
--- a/link.ld
+++ b/link.ld
@@ -13,6 +13,16 @@ SECTIONS
     _etext = .;
   } > FLASH
 
+  .data : ALIGN(4)
+  {
+    _data = .;
+    *(vtable)
+    *(.data*)
+    _edata = .;
+    _data_len = ABSOLUTE(_edata) - ABSOLUTE(_data);
+  } > SRAM AT > FLASH
+  _sidata = LOADADDR(.data);
+
   .nvm_data : ALIGN(PAGE_SIZE)
   {
     _nvram_data = .;
@@ -23,21 +33,12 @@ SECTIONS
     _nvram_end = .;
   } > FLASH 
 
-  .data : ALIGN(4)
-  {
-    _data = .;
-    *(vtable)
-    *(.data*)
-    _edata = .;
-  } > SRAM
-
-  ASSERT( (_edata - _data) <= 0, ".data section must be empty" )
-
    .bss :
   {
     _bss = .;
     *(.bss*)
     _ebss = .;
+    _bss_len = ABSOLUTE(_ebss) - ABSOLUTE(_bss);
 
     . = ALIGN(4);
     app_stack_canary = .;

--- a/link.ld
+++ b/link.ld
@@ -9,7 +9,6 @@ SECTIONS
     *(.text*)
     *(.rodata*) 
 
-    . = ALIGN(PAGE_SIZE);
     _etext = .;
   } > FLASH
 
@@ -20,11 +19,16 @@ SECTIONS
     *(.data*)
     _edata = .;
     _data_len = ABSOLUTE(_edata) - ABSOLUTE(_data);
+    FILL(0xa4a4);
+    /* Calculate padding so that .text + .data is a multiple of 64, as they
+     * will be concatenated into flash for the app image. */
+    . += (64 - (ABSOLUTE(_etext) - ABSOLUTE(_text) + ABSOLUTE(_edata) - ABSOLUTE(_data)) % 64) % 64;
   } > SRAM AT > FLASH
   _sidata = LOADADDR(.data);
 
   .nvm_data : ALIGN(PAGE_SIZE)
   {
+    . = ALIGN(PAGE_SIZE);
     _nvram_data = .;
     *(.nvm_data*)
     . = ALIGN(PAGE_SIZE);
@@ -60,6 +64,7 @@ SECTIONS
     libm.a ( * )
     libgcc.a ( * )
     *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    *(.ARM.extab*)
     *(.debug_info)
   }
 }

--- a/src/c/src.c
+++ b/src/c/src.c
@@ -14,6 +14,12 @@ void os_longjmp(unsigned int exception) {
   longjmp(try_context_get()->jmp_buf, exception);
 }
 
+extern char _data[];
+extern void* _data_len;
+extern char _sidata[];
+extern char _bss[];
+extern void* _bss_len;
+
 io_seph_app_t G_io_app;
 
 int c_main(void) {
@@ -56,6 +62,11 @@ int c_main(void) {
     #ifdef HAVE_BLE 
         LEDGER_BLE_init();
     #endif
+
+	// Yes, the length is the _address_ of _data_len, becuase it's the definition of the symbol at link time.
+	memset(&_bss, 0, (int) &_bss_len);
+	memcpy(&_data, &_sidata, (int) &_data_len);
+
         sample_main();
       }
       CATCH(EXCEPTION_IO_RESET) {


### PR DESCRIPTION
This provides a paddr for .data section directing it to flash, and initializes runtime globals from there in C before loading the Rust code.

This avoids having to deal with accidental undefined behavior from rust and extensive use of MaybeUninit at the global level for correct behavior.

A change to speculos is required to support this behavior, as currently it only maps the .text section when loading an app, but it appears to work for live devices as the whole FLASH section is copied to the .hex file during the "cargo ledger" build.